### PR TITLE
Fix instructions to change min-height

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ var simplemde = new SimpleMDE({
 To change the minimum height (before it starts auto-growing):
 
 ```CSS
-.CodeMirror {
-	min-height: 300px;
+.CodeMirror, .CodeMirror-scroll {
+	min-height: 200px;
 }
 ```
 


### PR DESCRIPTION
If you set `min-height` to value less than default 300px, you'll need to set it on `.CodeMirror-scroll` also for it to work.
