### PR TITLE
Gulp should be a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"bugs": {
 		"url": "https://github.com/NextStepWebs/simplemde-markdown-editor/issues"
 	},
-	"dependencies": {
+	"devDependencies": {
 		"gulp": "*",
 		"gulp-minify-css": "*",
 		"gulp-uglify": "*",


### PR DESCRIPTION
Gulp and plugins are used for development & build and not for actual production usage of the library.
So these should be installed as `devDependencies`.

This won't make a difference for your workflow, but if you install this package via npm, gulp + plugins isn't automatically installed (which is good, as you don't need them if you just depend on this package here).

PS: I really like the editor, thank you for your work!
