### PR TITLE
Fixing inconsistent behaviour between drawLink() and drawImage().

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -203,7 +203,7 @@ function drawLink(editor) {
 function drawImage(editor) {
 	var cm = editor.codemirror;
 	var stat = getState(cm);
-	_replaceSelection(cm, stat.image, '![](http://', ')');
+	_replaceSelection(cm, stat.image, '![', '](http://)');
 }
 
 


### PR DESCRIPTION
I've noticed inconsistent behaviour between links and images. Here's a screencast to show what I mean: http://recordit.co/VeU4EJQeWP

PS. What an amazing Markdown editor. I love the visual feedback given by inline styling, and the wysiwyg-like toolbar... yet this thing is NOT a wysiwyg editor, so it doesn't come with any of the buggy baggage that most wysiwyg editors struggle with. THANK YOU <3
