### PR TITLE
Pass through mode options

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ simplemde.value("This text will appear in the editor");
   - **unique_id**: You must set a unique identifier so that SimpleMDE can autosave. Something that separates this from other textareas.
   - **delay**: Delay between saves, in milliseconds. Defaults to `10000` (10s).
 - **previewRender**: Custom function for parsing the plaintext Markdown and returning HTML. Used when user previews.
+- **codeMirrorModeConfig**: Additional CodeMirror config options to pass through to gfm and markdown modes.
 
 ```JavaScript
 var simplemde = new SimpleMDE({
@@ -113,6 +114,9 @@ var simplemde = new SimpleMDE({
 		}, 250);
 		
 		return "Loading...";
+	},
+	codeMirrorModeConfig: {
+		highlightFormatting: true, taskLists: false
 	}
 });
 ```

--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -755,6 +755,8 @@ function SimpleMDE(options) {
 		}
 	}
 
+	options.codeMirrorModeConfig = options.codeMirrorModeConfig || {};
+
 	// Update this options
 	this.options = options;
 
@@ -830,12 +832,14 @@ SimpleMDE.prototype.render = function(el) {
 		if(cm.getOption("fullScreen")) cm.setOption("fullScreen", false);
 	};
 
-	var mode = "spell-checker";
-	var backdrop = "gfm";
-
+	var mode, backdrop;
 	if(options.spellChecker === false) {
-		mode = "gfm";
-		backdrop = undefined;
+		mode = options.codeMirrorModeConfig;
+		mode.name = 'gfm';
+	} else {
+		mode = 'spell-checker';
+		backdrop = options.codeMirrorModeConfig;
+		backdrop.name = 'gfm';
 	}
 
 	this.codemirror = CodeMirror.fromTextArea(el, {


### PR DESCRIPTION
Allow users to pass through CodeMirror mode config options, such as `highlightFormatting` to get extra CSS classes out of the markdown mode, or the not-yet-released [allowAtxHeaderWithoutSpace](https://github.com/codemirror/CodeMirror/commit/5cd327fbabdc6c42094869bb403cd7e570ad626b)
