### PR TITLE
Fix autosave

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -871,7 +871,7 @@ SimpleMDE.prototype.autosave = function() {
 	}
 
 	if(this.options.autosave.loaded !== true) {
-		if(localStorage.getItem(this.options.autosave.unique_id) != null)
+		if(localStorage.getItem(this.options.autosave.unique_id) != "")
 			this.codemirror.setValue(localStorage.getItem(this.options.autosave.unique_id));
 
 		this.options.autosave.loaded = true;


### PR DESCRIPTION
wrong comparison in localstorage, empty string not equal null

```
line 867 localStorage.setItem(simplemde.options.autosave.unique_id, "");
line 874 localStorage.getItem(this.options.autosave.unique_id) != null
```
