### PR TITLE
Fix autosave

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -871,7 +871,7 @@ SimpleMDE.prototype.autosave = function() {
 	}
 
 	if(this.options.autosave.loaded !== true) {
-		if(localStorage.getItem(this.options.autosave.unique_id) != null)
+		if(typeof localStorage.getItem(this.options.autosave.unique_id) == "string" && localStorage.getItem(this.options.autosave.unique_id) != "")
 			this.codemirror.setValue(localStorage.getItem(this.options.autosave.unique_id));
 
 		this.options.autosave.loaded = true;


### PR DESCRIPTION
After submit form with autosave we have emty string in local storage.
We won't set empty string instead of default form content.
