### PR TITLE
Add getState() support for code 

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -88,6 +88,8 @@ function getState(cm, pos) {
 			ret.quote = true;
 		} else if(data === 'strikethrough') {
 			ret.strikethrough = true;
+		} else if(data === 'comment') {
+			ret.code = true;
 		}
 	}
 	return ret;


### PR DESCRIPTION
And yes, CodeMirror internally labels it as "comment"

By the way, I've got a very comprehensive new version of `toggleCodeBlock` in the works.  It's context-sensitive so it'll handle fenced, indented, and inline code formats, both adding and removing, and based on any selection.  I've got a bit more testing and tweaking to do, but here's a heads up :)
