### PR TITLE
Add the replace selection text to the options.

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -260,16 +260,15 @@ function toggleOrderedList(editor) {
 	_toggleLine(cm, "ordered-list");
 }
 
-
 /**
  * Action for drawing a link.
  */
 function drawLink(editor) {
 	var cm = editor.codemirror;
 	var stat = getState(cm);
-	_replaceSelection(cm, stat.link, "[", "](http://)");
+   var options = editor.options;
+	_replaceSelection(cm, stat.link, options.replaceTexts.link);
 }
-
 
 /**
  * Action for drawing an img.
@@ -277,9 +276,9 @@ function drawLink(editor) {
 function drawImage(editor) {
 	var cm = editor.codemirror;
 	var stat = getState(cm);
-	_replaceSelection(cm, stat.image, "![](http://", ")");
+   var options = editor.options;
+   _replaceSelection(cm, stat.image, options.replaceTexts.image);
 }
-
 
 /**
  * Action for drawing a horizontal rule.
@@ -399,11 +398,13 @@ function togglePreview(editor) {
 		toggleSideBySide(editor);
 }
 
-function _replaceSelection(cm, active, start, end) {
+function _replaceSelection(cm, active, startEnd) {
 	if(/editor-preview-active/.test(cm.getWrapperElement().lastChild.className))
 		return;
 
 	var text;
+	var start = startEnd[0];
+	var end = startEnd[1];
 	var startPoint = cm.getCursor("start");
 	var endPoint = cm.getCursor("end");
 	if(active) {
@@ -789,6 +790,10 @@ var toolbarBuiltInButtons = {
 	}
 };
 
+var replaceTexts = {
+   link: ["[", "](http://)"],
+   image: ["![](http://", ")"]
+};
 
 /**
  * Interface of SimpleMDE.
@@ -859,6 +864,10 @@ function SimpleMDE(options) {
 
 	// Set default options for parsing config
 	options.parsingConfig = options.parsingConfig || {};
+
+
+	// Merging the replaceTexts, with the given options
+	options.replaceTexts = extend({}, replaceTexts, options.replaceTexts || {});
 
 
 	// Update this options

--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -287,7 +287,7 @@ function drawHorizontalRule(editor) {
 	var cm = editor.codemirror;
 	var stat = getState(cm);
 	var options = editor.options;
-	_replaceSelection(cm, stat.image, options.replaceTexts.HorizontalRule);}
+	_replaceSelection(cm, stat.image, options.replaceTexts.horizontalRule);}
 
 
 /**

--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -604,6 +604,50 @@ function _toggleBlock(editor, type, start_chars, end_chars) {
 	cm.focus();
 }
 
+/**
+ * Merge the properties of one object into another.
+ *
+ * @param {Object} target The object where the properties will be copied
+ * @param {Object} source The object whose properties will be copied
+ *
+ * @returns {Object}
+ */
+function _mergeProperties(target, source) {
+   for(var property in source) {
+      if (source.hasOwnProperty(property)) {
+         if (source[property] instanceof Array) {
+            target[property] = source[property].concat(target[property] instanceof Array ? target[property] : []);
+         } else if (
+               source[property] !== null &&
+               typeof source[property] === 'object' &&
+               source[property].constructor === Object
+            ) {
+            target[property] = mergeProperties(target[property] || {}, source[property]);
+         } else {
+            target[property] = source[property];
+         }
+      }
+   }
+
+   return target;
+}
+
+/**
+ * Merge an arbitrary number of objects into one.
+ * This function modifies the <code>target</code> object but also returns it.
+ *
+ * @param {Object} target The target object of the merge
+ *
+ * @returns {Object}
+ */
+function extend(target) {
+   for(var i = 1; i < arguments.length; i++) {
+      target = _mergeProperties(target, arguments[i]);
+   }
+
+   return target;
+}
+
 
 /* The right word count in respect for CJK. */
 function wordCount(data) {

--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -266,7 +266,7 @@ function toggleOrderedList(editor) {
 function drawLink(editor) {
 	var cm = editor.codemirror;
 	var stat = getState(cm);
-   var options = editor.options;
+	var options = editor.options;
 	_replaceSelection(cm, stat.link, options.replaceTexts.link);
 }
 
@@ -276,8 +276,8 @@ function drawLink(editor) {
 function drawImage(editor) {
 	var cm = editor.codemirror;
 	var stat = getState(cm);
-   var options = editor.options;
-   _replaceSelection(cm, stat.image, options.replaceTexts.image);
+	var options = editor.options;
+	_replaceSelection(cm, stat.image, options.replaceTexts.image);
 }
 
 /**
@@ -286,8 +286,8 @@ function drawImage(editor) {
 function drawHorizontalRule(editor) {
 	var cm = editor.codemirror;
 	var stat = getState(cm);
-	_replaceSelection(cm, stat.image, "", "\n\n-----\n\n");
-}
+	var options = editor.options;
+	_replaceSelection(cm, stat.image, options.replaceTexts.HorizontalRule);}
 
 
 /**
@@ -792,7 +792,8 @@ var toolbarBuiltInButtons = {
 
 var replaceTexts = {
    link: ["[", "](http://)"],
-   image: ["![](http://", ")"]
+   image: ["![](http://", ")"],
+   horizontalRule: ["", "\n\n-----\n\n"]
 };
 
 /**


### PR DESCRIPTION
The case I had was to remove the 'http://' from the drawImage function.
So I've created the ability to add the replace selection text to the options, and merge them with the defaults.

The usage will then be:

`
var simpleMDE = new SimpleMDE({
      '...': {},
      replaceTexts: {
         image: ["![](", ")"]
      });
`
