### PR TITLE
Added 'code' button to default toolbar

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -836,7 +836,7 @@ function SimpleMDE(options) {
 /**
  * Default toolbar elements.
  */
-SimpleMDE.toolbar = ["bold", "italic", "heading", "|", "quote", "unordered-list", "ordered-list", "|", "link", "image", "|", "preview", "side-by-side", "fullscreen", "guide"];
+SimpleMDE.toolbar = ["bold", "italic", "heading", "|", "code", "quote", "unordered-list", "ordered-list", "|", "link", "image", "|", "preview", "side-by-side", "fullscreen", "guide"];
 
 /**
  * Default markdown render.


### PR DESCRIPTION
My team thought that 'code' button is not even implemented in SimpleMDE, because they didn't see it on the demo page.
I think 'code' button is one the most important tools of markdown editors, so why not to add it by default in the toolbar :)
