### PR TITLE
Add jQuery validation example to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,24 @@ simplemde.isSideBySideActive(); // returns boolean
 simplemde.isFullscreenActive(); // returns boolean
 simplemde.clearAutosavedValue(); // no returned value
 ```
+## jQuery validation
+To mimic the jQuery validation on the editor, you can use the following code.
+
+```js
+    editor.codemirror.on("change", function() {
+        var element = $(editor.element);
+        $(element).val(editor.value());
+        $(element).trigger('keyup');
+    });
+
+    editor.codemirror.on("focus", function() {
+        $(editor.element).trigger('focus');
+    });
+
+    editor.codemirror.on("blur", function() {
+        $(editor.element).trigger('blur');
+    });
+```
 
 ## How it works
 SimpleMDE is an improvement of [lepture's Editor project](https://github.com/lepture/editor) and includes a great many number of changes. It is bundled with [CodeMirror](https://github.com/codemirror/codemirror) and depends on [Font Awesome](http://fortawesome.github.io/Font-Awesome/).


### PR DESCRIPTION
I've searched during a few hours to find a way to mimic the jQuery validation with the editor.
I've tried a lot of things but I think this one is the best one.

I've added a sample code to the documentation to show how to perform jQuery validation. If you need a jsFiddle to show you it works, please let me know.
