### PR TITLE
Remove AutoSave Function on Submit

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -1198,6 +1198,11 @@ SimpleMDE.prototype.autosave = function() {
 
 		if(simplemde.element.form != null && simplemde.element.form != undefined) {
 			simplemde.element.form.addEventListener("submit", function() {
+				/**
+				 * Remove the autosave function to stop resaving the MDE after the
+				 * submit has been started.
+				 */
+				SimpleMDE.prototype.autosave = function(){};
 				localStorage.removeItem("smde_" + simplemde.options.autosave.uniqueId);
 			});
 		}


### PR DESCRIPTION
Remove automatic save function on submit of form to stop MDE resaving
the value as the submit is still occurring.
This stops the already submitted value being redisplayed on load which
improves the end user experience.
