### PR TITLE
Added mark-selection plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ simplemde.value("This text will appear in the editor");
 - **tabSize**: If set, customize the tab size. Defaults to `2`.
 - **toolbar**: If set to `false`, hide the toolbar. Defaults to the [array of icons](#toolbar-icons).
 - **toolbarTips**: If set to `false`, disable toolbar button tips. Defaults to `true`.
+- **styleSelectedText**: If set to `false`, remove `.CodeMirror-selectedtext` class from selected lines. Defaults to `true`.
 
 ```JavaScript
 // Most options demonstrate the non-default behavior

--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -7,6 +7,7 @@ require("codemirror/addon/display/fullscreen.js");
 require("codemirror/mode/markdown/markdown.js");
 require("codemirror/addon/mode/overlay.js");
 require("codemirror/addon/display/placeholder.js");
+require("codemirror/addon/selection/mark-selection.js");
 require("codemirror/mode/gfm/gfm.js");
 require("codemirror/mode/xml/xml.js");
 require("spell-checker");
@@ -1483,7 +1484,8 @@ SimpleMDE.prototype.render = function(el) {
 		extraKeys: keyMaps,
 		lineWrapping: (options.lineWrapping === false) ? false : true,
 		allowDropFileTypes: ["text/plain"],
-		placeholder: options.placeholder || el.getAttribute("placeholder") || ""
+		placeholder: options.placeholder || el.getAttribute("placeholder") || "",
+		styleSelectedText: (options.styleSelectedText != undefined) ? options.styleSelectedText : true
 	});
 
 	if(options.forceSync === true) {


### PR DESCRIPTION
Hey guys,

I've been struggling to style the selected text the way I wanted and then I figured there is a CodeMirror plugin. So I've included it and made it configurable from `SimpleMDE`, by default it's on, as I think it's useful.

Hope it's helpful to others too.
