### PR TITLE
Fix issue #150: use correct paths for dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
 	]
   },
   "browser": {
-	"spell-checker": "./node_modules/codemirror-spell-checker/src/js/spell-checker.js",
-	"typo": "./node_modules/codemirror-spell-checker/src/js/typo.js"
+	"spell-checker": "codemirror-spell-checker/src/js/spell-checker.js",
+	"typo": "codemirror-spell-checker/src/js/typo.js"
   },
   "browserify-shim": {
 	"spell-checker": {


### PR DESCRIPTION
https://nodejs.org/api/modules.html specifies what paths are
correct. One should never explicitly put "node_modules" in
dependency paths because npm is under no obligation to put things
where you told it to look for them. Issue #150 arises when
SimpleMDE is a dependency in some other project, so it and its
dependencies are peers under that project's "node_modules", and
there is no "./node_modules" within the SimpleMDE folder.

TL/DR: npm tells you where it puts dependencies, not vice versa.
