### PR TITLE
Prevent onclick event from bubbling

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -1697,7 +1697,7 @@ SimpleMDE.prototype.createToolbar = function(items) {
 			if(item.action) {
 				if(typeof item.action === "function") {
 					el.onclick = function(e) {
-                        e.preventDefault();
+						e.preventDefault();
 						item.action(self);
 					};
 				} else if(typeof item.action === "string") {

--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -1696,7 +1696,8 @@ SimpleMDE.prototype.createToolbar = function(items) {
 			// bind events, special for info
 			if(item.action) {
 				if(typeof item.action === "function") {
-					el.onclick = function() {
+					el.onclick = function(e) {
+                        e.preventDefault();
 						item.action(self);
 					};
 				} else if(typeof item.action === "string") {


### PR DESCRIPTION
In my application the onclick event was bubbling up and causing Sammy.js to think it needed to navigate. By calling `preventDefault()` on the event this issue resolved.
