### PR TITLE
Fixed localStorage cleaning on a form submit denial of the autosave feature

### DIFF
--- a/debug/simplemde.debug.js
+++ b/debug/simplemde.debug.js
@@ -14443,10 +14443,12 @@ SimpleMDE.prototype.autosave = function() {
 			return;
 		}
 
-		if(simplemde.element.form != null && simplemde.element.form != undefined) {
+		if(this.element.form != null && this.element.form != undefined && !this.options.autosave.isEventListening) {
 			simplemde.element.form.addEventListener("submit", function() {
 				localStorage.removeItem("smde_" + simplemde.options.autosave.uniqueId);
+				simplemde.options.autosave.stop = true;
 			});
+			this.options.autosave.isEventListening = true;
 		}
 
 		if(this.options.autosave.loaded !== true) {
@@ -14458,6 +14460,9 @@ SimpleMDE.prototype.autosave = function() {
 			this.options.autosave.loaded = true;
 		}
 
+		if (this.options.autosave.stop)
+			return;
+            
 		localStorage.setItem("smde_" + this.options.autosave.uniqueId, simplemde.value());
 
 		var el = document.getElementById("autosaved");

--- a/debug/simplemde.js
+++ b/debug/simplemde.js
@@ -14440,10 +14440,12 @@ SimpleMDE.prototype.autosave = function() {
 			return;
 		}
 
-		if(simplemde.element.form != null && simplemde.element.form != undefined) {
+		if(this.element.form != null && this.element.form != undefined && !this.options.autosave.isEventListening) {
 			simplemde.element.form.addEventListener("submit", function() {
 				localStorage.removeItem("smde_" + simplemde.options.autosave.uniqueId);
+				simplemde.options.autosave.stop = true;
 			});
+			this.options.autosave.isEventListening = true;
 		}
 
 		if(this.options.autosave.loaded !== true) {
@@ -14455,6 +14457,9 @@ SimpleMDE.prototype.autosave = function() {
 			this.options.autosave.loaded = true;
 		}
 
+		if (this.options.autosave.stop)
+			return;
+            
 		localStorage.setItem("smde_" + this.options.autosave.uniqueId, simplemde.value());
 
 		var el = document.getElementById("autosaved");

--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -1537,10 +1537,12 @@ SimpleMDE.prototype.autosave = function() {
 			return;
 		}
 
-		if(simplemde.element.form != null && simplemde.element.form != undefined) {
+		if(this.element.form != null && this.element.form != undefined && !this.options.autosave.isEventListening) {
 			simplemde.element.form.addEventListener("submit", function() {
 				localStorage.removeItem("smde_" + simplemde.options.autosave.uniqueId);
+				simplemde.options.autosave.stop = true;
 			});
+			this.options.autosave.isEventListening = true;
 		}
 
 		if(this.options.autosave.loaded !== true) {
@@ -1552,6 +1554,9 @@ SimpleMDE.prototype.autosave = function() {
 			this.options.autosave.loaded = true;
 		}
 
+		if (this.options.autosave.stop)
+			return;
+            
 		localStorage.setItem("smde_" + this.options.autosave.uniqueId, simplemde.value());
 
 		var el = document.getElementById("autosaved");


### PR DESCRIPTION
Firstly, I didn't get why `npm install && gulp` on my machine corrupts the compiled files the way they lose the topmost code including the part where CodeMirror is required. So I couldn't have compiled the minified version properly. I've spent an hour trying to figure out what's wrong with no luck. The contributing.md file does not contain any info on development.

Now, the reason of PR. There was a bug with `localStorage.removeItem` at least on Chrome 49.0.2623.108.
When form had been submitted, the last saved by the autosave feature value, was restored on the next page load no matter what.  
Use case: I create a new item via CMS (uniqueId == model.name+object.id where object.id is empty), and then create another one. The second item form is populated with the old item's content of the SimpleMDE field.
I've found out there was an insane race condition, so I've added locks and it worked. I then copied the fix into all non-minified files.

BTW, guys, why didn't you merge in the master for so long?
