### PR TITLE
Add support for count Cyrillic words

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -1049,7 +1049,7 @@ function extend(target) {
 
 /* The right word count in respect for CJK. */
 function wordCount(data) {
-	var pattern = /[a-zA-Z0-9_\u0392-\u03c9]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\uac00-\ud7af]+/g;
+	var pattern = /[a-zA-Z0-9_\u0392-\u03c9\u0410-\u04F9]]+|[\u4E00-\u9FFF\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\uac00-\ud7af]+/g;
 	var m = data.match(pattern);
 	var count = 0;
 	if(m === null) return count;


### PR DESCRIPTION
Found that wordCcoun function is unable to count cyrillic words and characters because it's regex doesn't include that range.
So patch adds unicode range for Cyrillic characters
