### PR TITLE
Accept url when calling drawImage

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -630,18 +630,17 @@ function drawLink(editor) {
 /**
  * Action for drawing an img.
  */
-function drawImage(editor) {
+function drawImage(editor, url) {
 	var cm = editor.codemirror;
 	var stat = getState(cm);
 	var options = editor.options;
-	var url = "http://";
 	if(options.promptURLs) {
 		url = prompt(options.promptTexts.image);
 		if(!url) {
 			return false;
 		}
 	}
-	_replaceSelection(cm, stat.image, options.insertTexts.image, url);
+	_replaceSelection(cm, stat.image, options.insertTexts.image, url || "http://");
 }
 
 /**
@@ -1947,8 +1946,8 @@ SimpleMDE.prototype.cleanBlock = function() {
 SimpleMDE.prototype.drawLink = function() {
 	drawLink(this);
 };
-SimpleMDE.prototype.drawImage = function() {
-	drawImage(this);
+SimpleMDE.prototype.drawImage = function(url) {
+	drawImage(this, url);
 };
 SimpleMDE.prototype.drawTable = function() {
 	drawTable(this);


### PR DESCRIPTION
So I had this form where the user could upload images and see their thumbnails and then click them to add to the content. The thing is the editor didn't accept a `url` parameter when inserting images, the only option was to prompt the user for it. 

This change is really small but works like charm. I considered doing the same for `drawLink` but didn't have the time. Maybe later.

Great project by the way.
