### PR TITLE
Allow user to configure marked options

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ simplemde.value("This text will appear in the editor");
 - **previewRender**: Custom function for parsing the plaintext Markdown and returning HTML. Used when user previews.
 - **promptURLs**: If set to `true`, a JS alert window appears asking for the link or image URL. Defaults to `false`.
 - **renderingConfig**: Adjust settings for parsing the Markdown during previewing (not editing).
+  - **markedOptions**: Set default marked markdown renderer default [options](https://github.com/chjj/marked#options-1). `singleLineBreaks` and `codeSyntaxHighlighting` options below will take precedence.
   - **singleLineBreaks**: If set to `false`, disable parsing GFM single line breaks. Defaults to `true`.
   - **codeSyntaxHighlighting**: If set to `true`, will highlight using [highlight.js](https://github.com/isagalaev/highlight.js). Defaults to `false`. To use this feature you must include highlight.js on your page. For example, include the script and the CSS files like:<br>`<script src="https://cdn.jsdelivr.net/highlight.js/latest/highlight.min.js"></script>`<br>`<link rel="stylesheet" href="https://cdn.jsdelivr.net/highlight.js/latest/styles/github.min.css">`
 - **shortcuts**: Keyboard shortcuts associated with this instance. Defaults to the [array of shortcuts](#keyboard-shortcuts).

--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -1392,8 +1392,12 @@ function SimpleMDE(options) {
 SimpleMDE.prototype.markdown = function(text) {
 	if(marked) {
 		// Initialize
-		var markedOptions = {};
-
+		var markedOptions;
+		if(this.options && this.options.renderingConfig && this.options.renderingConfig.markedOptions) {
+			markedOptions = this.options.renderingConfig.markedOptions;
+		} else {
+			markedOptions = {};
+		}
 
 		// Update options
 		if(this.options && this.options.renderingConfig && this.options.renderingConfig.singleLineBreaks === false) {


### PR DESCRIPTION
The bundled markdown compiler, marked, has a number of options that can be configured by the user. Unfortunately, all those options are hidden inside SimpleMDE, and they cannot be configured.

It can be circumvented with `previewRender`, but if you just want to use marked with different configuration options with the compiled version of SimpleMDE, you have to include an additional copy of the marked JavaScript just so you can run it with some different configuration parameters inside your `previewRender` function.

This patch allows the user to set whatever configuration parameters they would like, instead of only the ones that have been threaded through specifically by `this.options.renderingConfig`. The existing parameters remain in-tact and shouldn't break any legacy code, but the new parameters will allow the user to configure the existing renderer should they need to.

JSFiddle: https://jsfiddle.net/2525aqky/1/

PS: I didn't know if I should include the compiled files, so I did. It incremented some versions, so if this is an issue I can update the PR with only the code and README changes.
