### PR TITLE
Add an option indicating a minimal height of the editable area.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ simplemde.value("This text will appear in the editor");
   - link
   - table
 - **lineWrapping**: If set to `false`, disable line wrapping. Defaults to `true`.
+- **minHeight**: A minimal height of the editable area. Should be a string containing a valid CSS value like: `"400px"`. Dafaults to `"300px"`.
 - **parsingConfig**: Adjust settings for parsing the Markdown during editing (not previewing).
   - **allowAtxHeaderWithoutSpace**: If set to `true`, will render headers without a space after the `#`. Defaults to `false`.
   - **strikethrough**: If set to `false`, will not process GFM strikethrough syntax. Defaults to `true`.

--- a/src/css/simplemde.css
+++ b/src/css/simplemde.css
@@ -1,16 +1,11 @@
 .CodeMirror {
     height: auto;
-    min-height: 300px;
     border: 1px solid #ddd;
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     padding: 10px;
     font: inherit;
     z-index: 1;
-}
-
-.CodeMirror-scroll {
-    min-height: 300px
 }
 
 .CodeMirror-fullscreen {

--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -1364,6 +1364,8 @@ function SimpleMDE(options) {
 	// Merging the shortcuts, with the given options
 	options.shortcuts = extend({}, shortcuts, options.shortcuts || {});
 
+	options.minHeight = options.minHeight || "300px";
+
 
 	// Change unique_id to uniqueId for backwards compatibility
 	if(options.autosave != undefined && options.autosave.unique_id != undefined && options.autosave.unique_id != "")
@@ -1498,6 +1500,8 @@ SimpleMDE.prototype.render = function(el) {
 		placeholder: options.placeholder || el.getAttribute("placeholder") || "",
 		styleSelectedText: (options.styleSelectedText != undefined) ? options.styleSelectedText : true
 	});
+
+	this.codemirror.getScrollerElement().style.minHeight = options.minHeight;
 
 	if(options.forceSync === true) {
 		var cm = this.codemirror;


### PR DESCRIPTION
Fixes #315.

Example: https://jsfiddle.net/35vj56kd/.
