### PR TITLE
Fix bug with inserting links and undoing things.

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -795,8 +795,9 @@ function _replaceSelection(cm, active, startEnd, url) {
 	var text;
 	var start = startEnd[0];
 	var end = startEnd[1];
-	var startPoint = cm.getCursor("start");
-	var endPoint = cm.getCursor("end");
+	var startPoint = {}, endPoint = {};
+	Object.assign(startPoint, cm.getCursor("start"));
+	Object.assign(endPoint, cm.getCursor("end"));
 	if(url) {
 		end = end.replace("#url#", url);
 	}


### PR DESCRIPTION
Fixes #98.
Generally reproducing the problem was much less complex than described in the issue, you just needed to click 'Insert link' and then undo, and repeat this at least once.

The problem inside the code was tricky, we creat two variables like so:

``` javascript
var startPoint = cm.getCursor("start");
var endPoint = cm.getCursor("end");
```

But as `getCursor` returns an object  they just points to objects stored probably somewhere in the CodeMirror!
Then we have:

``` javascript
startPoint.ch += start.length;
```

Which increments the cursor position which surely isn't stored in the history of the editor so calling `undo` doesn't moves this back (as in the case of `setSelection` or `setCursor` CodeMirror functions).

[Here's the demo](https://jsfiddle.net/zc38r4w2/).
