### PR TITLE
use remarkable instead of remarked for previewing to prevent XSS content

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,4 +328,4 @@ simplemde.clearAutosavedValue(); // no returned value
 ## How it works
 SimpleMDE began as an improvement of [lepture's Editor project](https://github.com/lepture/editor), but has now taken on an identity of its own. It is bundled with [CodeMirror](https://github.com/codemirror/codemirror) and depends on [Font Awesome](http://fontawesome.io).
 
-CodeMirror is the backbone of the project and parses much of the Markdown syntax as it's being written. This allows us to add styles to the Markdown that's being written. Additionally, a toolbar and status bar have been added to the top and bottom, respectively. Previews are rendered by [Marked](https://github.com/chjj/marked) using GFM.
+CodeMirror is the backbone of the project and parses much of the Markdown syntax as it's being written. This allows us to add styles to the Markdown that's being written. Additionally, a toolbar and status bar have been added to the top and bottom, respectively. Previews are rendered by [Remarkable](https://github.com/jonschlinkert/remarkable) using GFM, but with HTML disabled to prevent xss content, which is different from [marked](https://github.com/chjj/marked).

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "codemirror": "*",
     "codemirror-spell-checker": "*",
-    "marked": "*"
+    "marked": "*",
+    "remarkable": "^1.6.2"
   },
   "devDependencies": {
     "browserify": "*",

--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -11,7 +11,8 @@ require("codemirror/addon/selection/mark-selection.js");
 require("codemirror/mode/gfm/gfm.js");
 require("codemirror/mode/xml/xml.js");
 var CodeMirrorSpellChecker = require("codemirror-spell-checker");
-var marked = require("marked");
+//var marked = require("marked");
+var Remarkable = require("remarkable");
 
 
 // Some variables
@@ -1390,7 +1391,7 @@ function SimpleMDE(options) {
  * Default markdown render.
  */
 SimpleMDE.prototype.markdown = function(text) {
-	if(marked) {
+	/*if(marked) {
 		// Initialize
 		var markedOptions = {};
 
@@ -1415,7 +1416,30 @@ SimpleMDE.prototype.markdown = function(text) {
 
 		// Return
 		return marked(text);
-	}
+	}*/
+        if(Remarkable) {
+                var md = new Remarkable({
+                        html: false,
+                        xhtmlOut: true,
+                        breaks: false,
+                        highlight: function(str, lang) {
+                                if(typeof window.hljs != undefined && lang && window.hljs.getLanguage(lang)) {
+                                        try {
+                                                return window.hljs.highlight(lang, str).value;
+                                        } catch(err) {
+                                                //continue
+                                        }    
+                                }    
+                                try {
+                                        return window.hljs.highlightAuto(str).value;
+                                } catch(err) {
+                                        //continue
+                                }    
+                                return;
+                        }    
+                });  
+                return md.render(text);
+        }
 };
 
 /**


### PR DESCRIPTION
When the input string contains html content, 'marked' would simply render them as actual html entities, thus bring wired previewing effect. For example, when we input strings like `<textarea>123</textarea>`, preview would show an actual textarea input, script tag will also be rendered as well. If the content is user generated, it's likely to make the users feel that there could be a XSS vulnerability.

Should we change it with 'remarkable' with `html` option set to `false` to avoid this?
