### PR TITLE
Removed newline regex rewriting causing a mismatch.

### DIFF
--- a/debug/simplemde.debug.js
+++ b/debug/simplemde.debug.js
@@ -13373,7 +13373,6 @@ inline.gfm = merge({}, inline.normal, {
  */
 
 inline.breaks = merge({}, inline.gfm, {
-  br: replace(inline.br)('{2,}', '*')(),
   text: replace(inline.gfm.text)('{2,}', '*')()
 });
 

--- a/debug/simplemde.js
+++ b/debug/simplemde.js
@@ -13372,7 +13372,6 @@ inline.gfm = merge({}, inline.normal, {
  */
 
 inline.breaks = merge({}, inline.gfm, {
-  br: replace(inline.br)('{2,}', '*')(),
   text: replace(inline.gfm.text)('{2,}', '*')()
 });
 


### PR DESCRIPTION
The newline rendering does not work properly for the preview. The definition in wikipedia is: 
> Two spaces at the end of a line leave a line break.

But its breaking already after the first space at the end of a line.

Following markdown is rendered as it is shown up here:
```
one space at the end of the line (must not break) 
two spaces at the end of the line (must break)  
three spaces at the end of the line (must break)   
paragraph separaes through empty line

paragraph

text
```

But it must be rendered like this:

```
one space at the end of the line (must not break) two spaces at the end of the line (must break)  
three spaces at the end of the line (must break)   
paragraph separaes through empty line

paragraph

text
```

This error causes an inconsistency for the content-manager that sees the wrong preview rendering, and the end-user that sees the rendering from another tool (e.g. a 3rd party twig extension) that renders the line break correctly.

Please verify this.