### PR TITLE
allow promptTexts to be translated via options

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -1354,7 +1354,7 @@ function SimpleMDE(options) {
 
 
 	// Merging the promptTexts, with the given options
-	options.promptTexts = promptTexts;
+	options.promptTexts = extend({}, promptTexts, options.promptTexts || {});
 
 
 	// Merging the blockStyles, with the given options


### PR DESCRIPTION
the original PR already had an implementation of this behaviour but for some reason it was decided to strip it. unfortunately there’s no way to translate the promptTexts if they’re not merged with the provided options.

this allows the promptTexts to be translated/configured again.