### PR TITLE
Fix toggleFullscreen() if icon is hidden

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -211,12 +211,14 @@ function toggleFullScreen(editor) {
 
 
 	// Update toolbar button
-	var toolbarButton = editor.toolbarElements.fullscreen;
+	if (editor.toolbarElements.fullscreen) {
+		var toolbarButton = editor.toolbarElements.fullscreen;
 
-	if(!/active/.test(toolbarButton.className)) {
-		toolbarButton.className += " active";
-	} else {
-		toolbarButton.className = toolbarButton.className.replace(/\s*active\s*/g, "");
+		if(!/active/.test(toolbarButton.className)) {
+			toolbarButton.className += " active";
+		} else {
+			toolbarButton.className = toolbarButton.className.replace(/\s*active\s*/g, "");
+		}
 	}
 
 


### PR DESCRIPTION
Fix https://github.com/NextStepWebs/simplemde-markdown-editor/issues/417

This PR will make `toggleSideBySide()` work correctly if the toolbar does not contain the fullscreen icon.