### PR TITLE
Defaulting styleSelectedText to false if on a mobile device

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -1492,7 +1492,7 @@ SimpleMDE.prototype.render = function(el) {
 		lineWrapping: (options.lineWrapping === false) ? false : true,
 		allowDropFileTypes: ["text/plain"],
 		placeholder: options.placeholder || el.getAttribute("placeholder") || "",
-		styleSelectedText: (options.styleSelectedText != undefined) ? options.styleSelectedText : true
+		styleSelectedText: (options.styleSelectedText != undefined) ? options.styleSelectedText : !isMobile(),
 	});
 
 	if(options.forceSync === true) {


### PR DESCRIPTION
A 'fix' for issue #514. This change will default styleSelectedText to false if on a mobile device so that double clicking on text on a mobile device will now select the text. If styleSelectedText is set to true on a mobile device, then double clicking to select text on a mobile device would then deselect the text again. This would also affect other ways of selecting text on mobile devices (such as dragging selection handles or using an attached keyboards cursor keys to shift select text).