### PR TITLE
Change image in insertTexts to do the same as link

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -1275,7 +1275,7 @@ var toolbarBuiltInButtons = {
 
 var insertTexts = {
 	link: ["[", "](#url#)"],
-	image: ["![](", "#url#)"],
+	image: ["![", "](#url#)"],
 	table: ["", "\n\n| Column 1 | Column 2 | Column 3 |\n| -------- | -------- | -------- |\n| Text     | Text     | Text     |\n\n"],
 	horizontalRule: ["", "\n\n-----\n\n"]
 };


### PR DESCRIPTION
This fixes #534 

Changed the behaviour of image insertion to do the same as with link insertion putting the cursor in between the brackets.