### PR TITLE
Fix rendering function being called erroneously

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -779,8 +779,8 @@ function togglePreview(editor) {
 			toolbar.className += " active";
 			toolbar_div.className += " disabled-for-preview";
 		}
+		preview.innerHTML = editor.options.previewRender(editor.value(), preview);
 	}
-	preview.innerHTML = editor.options.previewRender(editor.value(), preview);
 
 	// Turn off side by side if needed
 	var sidebyside = cm.getWrapperElement().nextSibling;


### PR DESCRIPTION
I have a custom `previewRender` function that makes an Ajax call to my server's API which then returns the HTML result of the parsed markdown so I was taking a look at the network tab of the developer tools and I noticed that when I clicked the preview button in the toolbar again to **disable** it another request to my API would fire.

Now, I only gave a quick look to the code and after a quick inspection I saw no reason for this so... I guess I'm not breaking anything here.