### PR TITLE
Add a callback to toggle full screen

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -224,6 +224,9 @@ function toggleFullScreen(editor) {
 	var sidebyside = cm.getWrapperElement().nextSibling;
 	if(/editor-preview-active-side/.test(sidebyside.className))
 		toggleSideBySide(editor);
+	// Add toggle fullscreen callback
+	if ('fullScreenCallback' in editor.options)
+		editor.options.fullScreenCallback(cm.getOption("fullScreen"));
 }
 
 


### PR DESCRIPTION
When dealing webiste with headers.
It could be tricky to hide the headers when simpleMDE is full screen.
Adding a callback will largely simplify the case