### PR TITLE
Upgrade Gulp

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,8 @@
     "semi": [
       2,
       "always"
-    ]
+    ],
+    "no-useless-escape": "off"
   },
   "env": {
     "browser": true,


### PR DESCRIPTION
Currently we get an error when typing the `gulp` command, because the gulpfile is outdated.

This PR updates the gulpfile to be compatible with gulp4.

Also, it disables `no-useless-escape` eslint rule, which is too aggressive and returns a lot of errors in current base-code.