### PR TITLE
added innerHTML name option to toolbar item

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -108,6 +108,7 @@ function createIcon(options, enableTooltips, shortcuts) {
 		}
 	}
 
+	el.innerHMTL = options.name;
 	el.tabIndex = -1;
 	el.className = options.className;
 	return el;


### PR DESCRIPTION
Allows to insert material icons. Or any icon that is not relying on className but instead on innerHTML for its type.