### PR TITLE
Replace http:// with https:// in default link insertion

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -617,7 +617,7 @@ function drawLink(editor) {
 	var cm = editor.codemirror;
 	var stat = getState(cm);
 	var options = editor.options;
-	var url = "http://";
+	var url = "https://";
 	if(options.promptURLs) {
 		url = prompt(options.promptTexts.link);
 		if(!url) {
@@ -634,7 +634,7 @@ function drawImage(editor) {
 	var cm = editor.codemirror;
 	var stat = getState(cm);
 	var options = editor.options;
-	var url = "http://";
+	var url = "https://";
 	if(options.promptURLs) {
 		url = prompt(options.promptTexts.image);
 		if(!url) {


### PR DESCRIPTION
Most websites support https and redirect to https now