### PR TITLE
Fix problems with `marked@4.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "codemirror": "*",
     "codemirror-spell-checker": "*",
-    "marked": "*"
+    "marked": "^3.0.8"
   },
   "devDependencies": {
     "browserify": "*",


### PR DESCRIPTION
The 4.0.0 release of the `marked` package contains a breaking change that - guess what - breaks the SimpleMDE's script. The main change is that the `marked` package does NOT provide a default export anymore.

For more information please see the [release notes for `marked@4.0.0`](https://github.com/markedjs/marked/releases/tag/v4.0.0).